### PR TITLE
Make namespace declaration optional

### DIFF
--- a/config/laravel-typescript.php
+++ b/config/laravel-typescript.php
@@ -9,6 +9,8 @@ use Wovosoft\LaravelTypescript\Types\Type;
 return [
     'output_path'       => resource_path('js/types/models.d.ts'),
     'source_dir'        => app_path('Models'),
+    'declare_namespace' => true,
+    
     /**
      * Custom attributes should have return types defined.
      * But if it is not, then the return type should be this type.

--- a/src/Helpers/Generator.php
+++ b/src/Helpers/Generator.php
@@ -25,8 +25,11 @@ use Wovosoft\LaravelTypescript\Types\Type;
  */
 readonly class Generator
 {
+    private string $indent;
+    
     public function __construct(private ModelInspectionResult $result)
     {
+        $this->indent = config('laravel-typescript.declare_namespace') ? "\t" : "";
     }
 
     /**
@@ -66,14 +69,14 @@ readonly class Generator
         $typings = $this
             ->getDefinitions()
             ->implode(function (Definition $def, string $key) {
-                return "\t\t$key" . ($def->isUndefinable ? '?' : '') . ": $def;";
+                return $this->indent . "\t$key" . ($def->isUndefinable ? '?' : '') . ": $def;";
             }, PHP_EOL);
 
         $reflection = Reflection::model($this->result->getModel());
 
         return str($typings)
-            ->prepend("\texport interface " . $reflection->getShortName() . ' {' . PHP_EOL)
-            ->append(PHP_EOL . "\t}");
+            ->prepend($this->indent . "export interface " . $reflection->getShortName() . ' {' . PHP_EOL)
+            ->append(PHP_EOL . "$this->indent}");
     }
 
     /**

--- a/src/LaravelTypescript.php
+++ b/src/LaravelTypescript.php
@@ -78,16 +78,20 @@ class LaravelTypescript
             ])
             ->map(function (Collection $modelClasses, string $namespace) {
                 $namespace = ModelInspector::getQualifiedNamespace($namespace);
+                $modelTypes = $modelClasses
+                ->map(
+                    fn(string $modelClass) => (string)ModelInspector::new($modelClass)
+                        ->getInspectionResult()
+                        ->getGenerator()
+                )
+                ->implode(fn(string $content) => $content, PHP_EOL . PHP_EOL);
+                if (config('laravel-typescript.declare_namespace')) {
+                    return "declare namespace $namespace {" . PHP_EOL
+                        . $modelTypes
+                        . PHP_EOL . '}' . PHP_EOL;
+                }
 
-                return "declare namespace $namespace {" . PHP_EOL
-                    . $modelClasses
-                        ->map(
-                            fn(string $modelClass) => (string)ModelInspector::new($modelClass)
-                                ->getInspectionResult()
-                                ->getGenerator()
-                        )
-                        ->implode(fn(string $content) => $content, PHP_EOL . PHP_EOL)
-                    . PHP_EOL . '}' . PHP_EOL;
+                return $modelTypes . PHP_EOL;
             })
             ->implode(fn(string $content) => $content, PHP_EOL . PHP_EOL);
     }


### PR DESCRIPTION
I'm no typescript expert, but for some reason I couldn't use the generated types in my Vue components unless I removed the namespace declaration in the type definitions.
So I figured some other people might find it useful to ignore namespace declaration.
Let me know if you'd like something changed.